### PR TITLE
Fix custom templates in extra-config

### DIFF
--- a/engine/actions/extra-config.php
+++ b/engine/actions/extra-config.php
@@ -61,7 +61,10 @@ if (!is_array($extras[$plugin])) {
 
 		//
 		// Include required script file
+		ob_start();
 		@include extras_dir . '/' . $extras[$plugin]['dir'] . '/' . $extras[$plugin][$stype];
+		$main_admin = ob_get_contents();
+		ob_end_clean();
 
 		//
 		// Run install function if it exists in file


### PR DESCRIPTION
В плагинах, в админке которых юзается кастомный шаблон вывод происходит сразу, а не в шаблон админки, пример до
![image](https://user-images.githubusercontent.com/1254277/59453565-9b311800-8e29-11e9-967f-501845423d79.png)
после:
![image](https://user-images.githubusercontent.com/1254277/59453600-b00dab80-8e29-11e9-9e2b-3b063956e379.png)
