### PR TITLE
Исправление ошибки с патчами при установки ч/з Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "config": {
+        "preferred-install": "source",
         "vendor-dir": "vendor"
     },
     "require": {
@@ -17,5 +18,4 @@
             }
         }
     }
-    
-} 
+}

--- a/patches/composer/1.diff
+++ b/patches/composer/1.diff
@@ -1,3 +1,4 @@
+
 --- a/vendor/twig/twig/src/Environment.php
 +++ b/vendor/twig/twig/src/Environment.php
 @@ -1403,6 +1403,37 @@

--- a/patches/composer/1.diff
+++ b/patches/composer/1.diff
@@ -1,4 +1,3 @@
-
 --- a/vendor/twig/twig/src/Environment.php
 +++ b/vendor/twig/twig/src/Environment.php
 @@ -1403,6 +1403,37 @@

--- a/patches/composer/2.diff
+++ b/patches/composer/2.diff
@@ -1,5 +1,5 @@
 --- a/vendor/twig/twig/src/Extension/StagingExtension.php
-+++ b/vendor/twig/twig/src/Extension/StagingExtension (копия).php
++++ b/vendor/twig/twig/src/Extension/StagingExtension.php
 @@ -89,6 +89,11 @@
          $this->globals[$name] = $value;
      }


### PR DESCRIPTION
В файле `1.diff` поставлен перенос строки для того, чтобы гитхаб подхватил изменения в файле. Так как его необходимо было пересохранить в Unix (LF). Иначе он не применялся.

Эта (пустая) строка удалена во втором коммите пулла.