### PR TITLE
Update upload.class.php

### DIFF
--- a/engine/includes/classes/upload.class.php
+++ b/engine/includes/classes/upload.class.php
@@ -871,7 +871,7 @@ class image_managment
 
     // Params:
     //	rpc			- flag if we're called via RPC call
-    function create_thumb($dir, $file, $sizeX, $sizeY, $quality = 0, $param)
+    function create_thumb($dir, $file, $sizeX, $sizeY, $quality = 0, $param = [])
     {
 
         global $lang;


### PR DESCRIPTION
При прикреплении иконки к категории возникает ошибка:

> Too few arguments to function image_managment::create_thumb(), 5 passed in C:\xampp\htdocs\ngcms\engine\actions\categories.php on line 430 and exactly 6 expected