### PR TITLE
Update functions.inc.php

### DIFF
--- a/engine/includes/inc/functions.inc.php
+++ b/engine/includes/inc/functions.inc.php
@@ -548,7 +548,7 @@ function msg($params, $mode = 0, $disp = -1)
             return $message;
         default:
             if ($PHP_SELF == 'admin.php') {
-                $notify = $message;
+                $notify .= $message;
             } else {
                 $template['vars']['mainblock'] .= $message;
             }


### PR DESCRIPTION
При редактировании новости и прикреплении изображения, размеры которого превышают допустимые, не выводятся сообщения об ошибках загрузки изображения.

То есть, сообщения не накапливаются в глобальную переменную `$notify`, а каждое последующее заменяет предыдущее.