### PR TITLE
Переместит зависимость `ext-memcached` Composer в раздел `suggest`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "ext-pdo": "*",
         "ext-zip": "*",
         "ext-zlib": "*",
-        "ext-memcached": "*",
         "ext-iconv": "*",
         "phpmailer/phpmailer": "6.*",
         "twig/twig": "^3.0",
@@ -38,6 +37,9 @@
         "psr/container": "^2.0"
     },
     "require-dev": {},
+    "suggest": {
+        "ext-memcached": "Required to use the Memcached."
+    },
     "autoload": {},
     "autoload-dev": {},
     "minimum-stability": "dev",


### PR DESCRIPTION
Не знаю насколько плотно он используется в NGCMS, но вот ссылки на поиск в репозиториях по ключевому слову **memcache** [ядро](https://github.com/vponomarev/ngcms-core/search?q=memcache) и [плагины](https://github.com/vponomarev/ngcms-plugins/search?q=memcache).

Быстро-ссылка на всякий случай https://getcomposer.org/doc/04-schema.md#suggest.