### PR TITLE
[PHP 8.0] Тип `callable` при регистрации обработчиков плагинов

### DIFF
--- a/engine/includes/inc/extras.inc.php
+++ b/engine/includes/inc/extras.inc.php
@@ -548,10 +548,23 @@ function add_act($item, $function, $arguments = 0, $priority = 5)
     return true;
 }
 
-// * New Style function name for `add_act`
-function registerActionHandler($action, $function, $priority = 5)
-{
-    return add_act($action, $function, 0, $priority);
+/**
+ * Register handler's action.
+ *
+ * New Style function name for `add_act`.
+ *
+ * @param string $action
+ * @param string $handler
+ * @param integer $priority
+ *
+ * @return boolean
+ */
+function registerActionHandler(
+    string $action,
+    string $handler,
+    int $priority = 5
+): bool {
+    return add_act($action, $handler, 0, $priority);
 }
 
 // * New Style function name for 'exec_acts'
@@ -907,17 +920,32 @@ function pluginsGetList()
     return $extras;
 }
 
-//
-// Add plugin's page
-//
-function register_plugin_page($pname, $mode, $func_name, $show_template = 1)
-{
+/**
+ * Register plugin's page.
+ *
+ * @param string $plugin
+ * @param string $page
+ * @param string $handler
+ * @param boolean $show_template Not used.
+ *
+ * @return void
+ */
+function register_plugin_page(
+    string $plugin,
+    string $page,
+    string $handler,
+    bool $show_template = true
+): void {
     global $PPAGES;
 
-    if (!isset($PPAGES[$pname]) || !is_array($PPAGES[$pname])) {
-        $PPAGES[$pname] = [];
+    if (!isset($PPAGES[$plugin]) || !is_array($PPAGES[$plugin])) {
+        $PPAGES[$plugin] = [];
     }
-    $PPAGES[$pname][$mode] = ['func' => $func_name, 'mode' => $mode];
+
+    $PPAGES[$plugin][$page] = [
+        'func' => $handler,
+        'mode' => $page,
+    ];
 }
 
 //
@@ -1202,11 +1230,23 @@ function rpcRegisterFunction($name, $instance, $permanent = false)
     $RPCFUNC[$name] = $instance;
 }
 
-// Register TWIG function call
-function twigRegisterFunction($pluginName, $funcName, $instance)
-{
+/**
+ * Register function call TWIG.
+ *
+ * @param string $plugin
+ * @param string $action
+ * @param string $handler
+ *
+ * @return void
+ */
+function twigRegisterFunction(
+    string $plugin,
+    string $action,
+    string $handler
+): void {
     global $TWIGFUNC;
-    $TWIGFUNC[$pluginName.'.'.$funcName] = $instance;
+
+    $TWIGFUNC[$plugin.'.'.$action] = $handler;
 }
 
 //

--- a/engine/includes/inc/extras.inc.php
+++ b/engine/includes/inc/extras.inc.php
@@ -554,14 +554,14 @@ function add_act($item, $function, $arguments = 0, $priority = 5)
  * New Style function name for `add_act`.
  *
  * @param string $action
- * @param string $handler
+ * @param callable|string $handler
  * @param integer $priority
  *
  * @return boolean
  */
 function registerActionHandler(
     string $action,
-    string $handler,
+    callable|string $handler,
     int $priority = 5
 ): bool {
     return add_act($action, $handler, 0, $priority);
@@ -925,7 +925,7 @@ function pluginsGetList()
  *
  * @param string $plugin
  * @param string $page
- * @param string $handler
+ * @param callable|string $handler
  * @param boolean $show_template Not used.
  *
  * @return void
@@ -933,7 +933,7 @@ function pluginsGetList()
 function register_plugin_page(
     string $plugin,
     string $page,
-    string $handler,
+    callable|string $handler,
     bool $show_template = true
 ): void {
     global $PPAGES;
@@ -1235,14 +1235,14 @@ function rpcRegisterFunction($name, $instance, $permanent = false)
  *
  * @param string $plugin
  * @param string $action
- * @param string $handler
+ * @param callable|string $handler
  *
  * @return void
  */
 function twigRegisterFunction(
     string $plugin,
     string $action,
-    string $handler
+    callable|string $handler
 ): void {
     global $TWIGFUNC;
 
@@ -1329,7 +1329,7 @@ function _MASTER_defaultRUN($pluginName, $handlerName, $params, &$skip, $handler
 
     $pcall = $PPAGES[$pluginName][$handlerName];
 
-    if (is_array($pcall) && function_exists($pcall['func'])) {
+    if (is_array($pcall) && is_callable($pcall['func'])) {
         // Make page title
         $SYSTEM_FLAGS['info']['title']['group'] = $lang['loc_plugin'];
 

--- a/engine/includes/inc/functions.inc.php
+++ b/engine/includes/inc/functions.inc.php
@@ -3193,25 +3193,32 @@ function getCurrentNewsCategory()
     return [($CurrentHandler['handlerName'] == 'by.category') ? 'short' : 'full', $SYSTEM_FLAGS['news']['currentCategory.id'], $SYSTEM_FLAGS['news']['db.id']];
 }
 
-// Call plugin execution via TWIG
-function twigCallPlugin($funcName, $params)
+/**
+ * Call plugin execution via TWIG.
+ *
+ * @param string $alias
+ * @param array $params
+ *
+ * @return mixed
+ */
+function twigCallPlugin(string $alias, array $params = []): mixed
 {
     global $TWIGFUNC;
 
     // Try to preload function if required
-    if (!isset($TWIGFUNC[$funcName])) {
-        if (preg_match("#^(.+?)\.(.+?)$#", $funcName, $m)) {
+    if (!isset($TWIGFUNC[$alias])) {
+        if (preg_match("#^(.+?)\.(.+?)$#", $alias, $m)) {
             loadPlugin($m[1], 'twig');
         }
     }
 
-    if (!isset($TWIGFUNC[$funcName])) {
-        echo "ERROR :: callPlugin - no function [$funcName]<br/>\n";
+    if (!isset($TWIGFUNC[$alias])) {
+        echo "ERROR :: callPlugin - no function [{$alias}]<br/>\n";
 
-        return;
+        return null;
     }
 
-    return call_user_func($TWIGFUNC[$funcName], $params);
+    return call_user_func($TWIGFUNC[$alias], $params);
 }
 
 // Truncate HTML


### PR DESCRIPTION
Обычно регистрация плагинов выполняется следующим образом:

```php
register_plugin_page('faq', '', 'plugin_faq');

function plugin_faq()
{
    // ...
}

function plug_faq(...)
{
    // ...
}

function plugin_faq_showTwig($params)
{
    // ...
    return plug_faq(...);
}

twigRegisterFunction('faq', 'show', plugin_faq_showTwig);
```

После внесения изменений, будет расширена возможность регистрации плагинов с использованием классов и пространств имен:

```php
use Plugins\Something;

$something= new Something();

registerActionHandler('index', [$something, 'something']);

register_plugin_page('something', '', fn(array $params = []) => $something->indexPage($params));

twigRegisterFunction('something', 'widget', function(array $params = []) {
    return ...;
});
```
